### PR TITLE
Update status to Implemented for relevant ZIPs

### DIFF
--- a/zips/zip-2.md
+++ b/zips/zip-2.md
@@ -1,6 +1,6 @@
 |  ZIP | Title | Status| Type | Author | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd)
 |--|--|--|--| -- | -- | -- |
-| 1  | Zilliqa Internal Transactions | Draft | Standards Track  | Haichuan Liu <haichuan@zilliqa.com> <br> Xiaohuo Ren <lulu@zilliqa.com>| 2020-01-15 | 2020-02-24
+| 1  | Zilliqa Internal Transactions | Implemented | Standards Track  | Haichuan Liu <haichuan@zilliqa.com> <br> Xiaohuo Ren <lulu@zilliqa.com>| 2020-01-15 | 2020-06-08
 
 ## Abstract
 

--- a/zips/zip-4.md
+++ b/zips/zip-4.md
@@ -1,6 +1,6 @@
 | ZIP | Title                        | Status | Type  | Author                                                                                                                       | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
 | --- | ---------------------------- | ------ | ----- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
-| 4   | GetMinerNodes API | Draft  | Standards Track | Antonio Nunez <antonio@zilliqa.com> | 2020-02-12           | 2020-02-12           |
+| 4   | GetMinerNodes API | Implemented  | Standards Track | Antonio Nunez <antonio@zilliqa.com> | 2020-02-12           | 2020-06-08           |
 
 ## Abstract
 

--- a/zips/zip-6.md
+++ b/zips/zip-6.md
@@ -1,6 +1,6 @@
 |  ZIP | Title | Status| Type | Author | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd)
 |--|--|--|--| -- | -- | -- |
-| 6  | Zilliqa Isolated Server | Draft | Standards Track  | Kaustubh Shamshery <kaustubh@zilliqa.com>| 2020-05-06 | 2020-05-06
+| 6  | Zilliqa Isolated Server | Implemented | Standards Track  | Kaustubh Shamshery <kaustubh@zilliqa.com>| 2020-05-06 | 2020-06-08
 
 ## Abstract
 


### PR DESCRIPTION
ZIP-2, ZIP-4, and ZIP-6 have already been state-of-the-art for a while now and should be OK to move to Implemented status.